### PR TITLE
Copilot/fix GitHub pages upload error

### DIFF
--- a/.github/workflows/upload-pages-artifact.yml
+++ b/.github/workflows/upload-pages-artifact.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 


### PR DESCRIPTION
This pull request introduces a minor update to the permissions in the GitHub Actions workflow configuration. The change increases the permission level for the `contents` scope from `read` to `write`, allowing the workflow to make changes to repository contents if needed.